### PR TITLE
Remove Generation 8 Pokemon

### DIFF
--- a/src/components/Homepage/homeSlice.js
+++ b/src/components/Homepage/homeSlice.js
@@ -25,7 +25,7 @@ export const fetchPokemonList = createAsyncThunk(
   async (payload, { rejectWithValue }) => {
     try {
       const response = await axios.get(
-        'https://pokeapi.co/api/v2/pokemon?limit=898'
+        'https://pokeapi.co/api/v2/pokemon?limit=809'
       )
       return response.data.results
     } catch (err) {

--- a/src/helpers/box.js
+++ b/src/helpers/box.js
@@ -26,7 +26,7 @@ export const responsiveProps = (property, values) => {
     // same values for all screen sizes
     return property ? `${property}: ${values};` : `${values}`
   } else if (typeof values === 'object') {
-    return dimensions.map((d) => {
+    return dimensions.map(d => {
       if (breakpoints[d] && values[d] !== undefined) {
         return css`
           ${breakpointStyle(
@@ -47,7 +47,7 @@ export const responsiveProps = (property, values) => {
  * @param {number|string|Object} sizeProp The sizes prop.
  * @returns {string[]} Returns the flex-basis styles for the multiple breakpoints.
  */
-export const flexStyle = (sizeProp) => {
+export const flexStyle = sizeProp => {
   if (typeof sizeProp === 'number') {
     return css`
       flex-basis: ${(sizeProp / 12) * 100}%;
@@ -58,17 +58,25 @@ export const flexStyle = (sizeProp) => {
       flex-grow: 0;
     `
   } else {
-    return dimensions.map((d) => {
+    return dimensions.map(d => {
       if (breakpoints[d] && sizeProp[d] && sizeProp[d] !== 'auto') {
         return css`
           ${breakpointStyle(
             breakpoints[d],
-            `flex-basis: ${(sizeProp[d] / 12) * 100}%;`
+            css`
+              flex-basis: ${(sizeProp[d] / 12) * 100}%;
+            `
           )}
         `
       } else if (breakpoints[d] && sizeProp[d] === 'auto') {
         return css`
-          ${breakpointStyle(breakpoints[d], `flex-basis: auto; flex-grow: 1;`)}
+          ${breakpointStyle(
+            breakpoints[d],
+            css`
+              flex-basis: auto;
+              flex-grow: 1;
+            `
+          )}
         `
       }
     })

--- a/src/helpers/gameVersion.js
+++ b/src/helpers/gameVersion.js
@@ -164,6 +164,7 @@ const gameVersions = [
     group: 'lets-go-pikachu-lets-go-eevee',
     generation: 'Generation VII',
   },
+  /** 
   {
     name: 'Sword',
     value: 'sword',
@@ -176,6 +177,7 @@ const gameVersions = [
     group: 'sword-shield',
     generation: 'Generation VIII',
   },
+  */
 ]
 
 const generations = [
@@ -214,11 +216,13 @@ const generations = [
     genDescription: 'Generation VII',
     gameVersion: 'sun',
   },
+  /** 
   {
     genValue: 'generation-viii',
     genDescription: 'Generation VIII',
     gameVersion: 'sword',
   },
+  */
 ]
 
 const mapIdToGeneration = id => {
@@ -236,9 +240,9 @@ const mapIdToGeneration = id => {
     return 'generation-vi'
   } else if (id > 721 && id <= 809) {
     return 'generation-vii'
-  } else if (id > 809 && id <= 898) {
+  } /** else if (id > 809 && id <= 898) {
     return 'generation-viii'
-  } else {
+  } */ else {
     return 'all'
   }
 }


### PR DESCRIPTION
This PR removes generation 8 pokemon from the app since it's not fully support by PokeApi at this time.