### PR TITLE
Type Info Section

### DIFF
--- a/src/components/BaseStyles/headings.js
+++ b/src/components/BaseStyles/headings.js
@@ -29,4 +29,32 @@ const MainHeading = styled(motion.h1)`
   `}
 `
 
-export { MainHeading }
+const PageHeading = styled.h1`
+  font-size: 2.5rem;
+  line-height: 3rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  text-align: center;
+
+  ${({ theme }) => css`
+    @media ${theme.device.xs} {
+      font-size: 3.5rem;
+      line-height: 4rem;
+    }
+    @media ${theme.device.sm} {
+      font-size: 5rem;
+      line-height: 5.5rem;
+    }
+    @media ${theme.device.md} {
+      font-size: 8rem;
+      line-height: 8.5rem;
+    }
+    @media ${theme.device.lg} {
+      text-align: left;
+      font-size: 5.3rem;
+      line-height: 5.5rem;
+    }
+  `}
+`
+
+export { MainHeading, PageHeading }

--- a/src/components/BaseStyles/typography.js
+++ b/src/components/BaseStyles/typography.js
@@ -56,4 +56,32 @@ const SectionMessage = styled(motion.p)`
   `}
 `
 
-export { SectionTitle, SectionSubTitle, SectionMessage }
+const JpnName = styled(motion.span)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: -1;
+  // text
+  word-break: break-all;
+  line-height: 1;
+  text-transform: uppercase;
+  text-align: center;
+  font-size: 3rem;
+  font-weight: bold;
+  user-select: none;
+  width: 1em;
+
+  ${({ theme }) => css`
+    color: ${theme.jpnName.color};
+
+    @media ${theme.device.xxs} {
+      display: none;
+    }
+    color: black;
+    @media ${theme.device.md} {
+      display: inline-block;
+    }
+  `}
+`
+
+export { SectionTitle, SectionSubTitle, SectionMessage, JpnName }

--- a/src/components/Box/StyledBox.js
+++ b/src/components/Box/StyledBox.js
@@ -73,6 +73,13 @@ export default styled(motion.div)`
       max-width: ${boxConfig.constrained};
     `};
 
+  /** Position */
+  ${({ relative }) =>
+    relative &&
+    css`
+      position: relative;
+    `}
+
   /** gutter */
   ${({ padding, withGutter }) => !padding && withGutter && gutterStyle()}
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,14 +11,14 @@ import { Heading, SelectContainer } from './styledHeader'
 // Info
 import { gameVersions } from '../../helpers/gameVersion'
 
-export default function HeaderComponent() {
+export default function HeaderComponent({ withGameVersion = true, ...rest }) {
   // dispatch
   const dispatch = useDispatch()
   // game version
   const gameVersion = useSelector(state => state.game.version)
 
   return (
-    <Box as="header" margin="2rem 0">
+    <Box as="header" margin="2rem 0" {...rest}>
       <Box
         constrained
         withGutter
@@ -32,23 +32,25 @@ export default function HeaderComponent() {
             <Heading>PokeStats</Heading>
           </Link>
           {/** Select */}
-          <SelectContainer direction="row" justify="flex-start">
-            <label id="header_generation" htmlFor="header_gen_select">
-              Game Version:
-            </label>
-            <select
-              aria-labelledby="header_generation"
-              id="header_gen_select"
-              value={gameVersion}
-              onChange={e => dispatch(changeVersion(e.target.value))}
-            >
-              {gameVersions.map(({ name, value }, index) => (
-                <option key={index} value={value}>
-                  {name}
-                </option>
-              ))}
-            </select>
-          </SelectContainer>
+          {withGameVersion && (
+            <SelectContainer direction="row" justify="flex-start">
+              <label id="header_generation" htmlFor="header_gen_select">
+                Game Version:
+              </label>
+              <select
+                aria-labelledby="header_generation"
+                id="header_gen_select"
+                value={gameVersion}
+                onChange={e => dispatch(changeVersion(e.target.value))}
+              >
+                {gameVersions.map(({ name, value }, index) => (
+                  <option key={index} value={value}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            </SelectContainer>
+          )}
         </div>
         <Autocomplete
           width="350px"

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -16,7 +16,7 @@ const LayoutContainer = styled(BoxWrapper)`
 export const MainContainer = styled(motion.main)`
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: ${({ align }) => (align ? align : 'center')};
   justify-content: ${({ justify }) => (justify ? justify : 'center')};
   margin: 0 auto;
   width: 100%;

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -30,13 +30,14 @@ export default function Layout({
   withFooter,
   withHeader,
   withMain = true,
+  withGameVersion = true,
   children,
   mainKey,
   ...rest
 }) {
   return (
     <LayoutContainer direction="column" width="100%" noGutter>
-      {withHeader && <Header />}
+      {withHeader && <Header withGameVersion={withGameVersion} />}
       {withMain ? (
         <MainContainer key={mainKey} {...rest}>
           {children}

--- a/src/components/Pokemon/Details/StyledDetails.js
+++ b/src/components/Pokemon/Details/StyledDetails.js
@@ -1,34 +1,6 @@
 import styled, { css } from 'styled-components'
 import Box from '../../Box'
 
-const Name = styled.h1`
-  font-size: 2.5rem;
-  line-height: 3rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-  text-align: center;
-
-  ${({ theme }) => css`
-    @media ${theme.device.xs} {
-      font-size: 3.5rem;
-      line-height: 4rem;
-    }
-    @media ${theme.device.sm} {
-      font-size: 5rem;
-      line-height: 5.5rem;
-    }
-    @media ${theme.device.md} {
-      font-size: 8rem;
-      line-height: 8.5rem;
-    }
-    @media ${theme.device.lg} {
-      text-align: left;
-      font-size: 5.3rem;
-      line-height: 5.5rem;
-    }
-  `}
-`
-
 // type
 const TypeContainer = styled(Box)``
 
@@ -47,4 +19,4 @@ const Flavor = styled.p`
   `}
 `
 
-export { Name, TypeContainer, Genera, Flavor }
+export { TypeContainer, Genera, Flavor }

--- a/src/components/Pokemon/Details/index.js
+++ b/src/components/Pokemon/Details/index.js
@@ -8,8 +8,8 @@ import BoxWrapper from '../../Box/StyledBox'
 import Loading from '../../Loading'
 import TypeBadge from '../../TypeBadge'
 // styles
-import { Table, Numbered } from '../../BaseStyles'
-import { Name, TypeContainer, Genera, Flavor } from './StyledDetails'
+import { PageHeading, Table, Numbered } from '../../BaseStyles'
+import { TypeContainer, Genera, Flavor } from './StyledDetails'
 
 export default function Details({ sizes, ...rest }) {
   // pokemon info
@@ -97,7 +97,7 @@ export default function Details({ sizes, ...rest }) {
           key={`pokemon-details-${id}`}
           {...rest}
         >
-          <Name>{removeDash(name)}</Name>
+          <PageHeading>{removeDash(name)}</PageHeading>
           {types.length > 0 && (
             <TypeContainer
               width="auto"

--- a/src/components/Pokemon/FeatureImage/StyledFeatureImage.js
+++ b/src/components/Pokemon/FeatureImage/StyledFeatureImage.js
@@ -40,32 +40,4 @@ const ImageContainer = styled(Box)`
   }
 `
 
-const JpnName = styled(motion.span)`
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: -1;
-  // text
-  word-break: break-all;
-  line-height: 1;
-  text-transform: uppercase;
-  text-align: center;
-  font-size: 3rem;
-  font-weight: bold;
-  user-select: none;
-  width: 1em;
-
-  ${({ theme }) => css`
-    color: ${theme.jpnName.color};
-
-    @media ${theme.device.xxs} {
-      display: none;
-    }
-    color: black;
-    @media ${theme.device.md} {
-      display: inline-block;
-    }
-  `}
-`
-
-export { ImageContainer, JpnName }
+export { ImageContainer }

--- a/src/components/Pokemon/FeatureImage/index.js
+++ b/src/components/Pokemon/FeatureImage/index.js
@@ -3,7 +3,8 @@ import Image from '../../Image'
 // helpers
 import { scaleInVariant } from '../../../helpers/animations'
 // styles
-import { ImageContainer, JpnName } from './StyledFeatureImage'
+import { JpnName } from '../../BaseStyles'
+import { ImageContainer } from './StyledFeatureImage'
 
 export default function FeaturedImage({
   pokemonNames,

--- a/src/components/Pokemon/Multipliers/index.js
+++ b/src/components/Pokemon/Multipliers/index.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { AnimatePresence } from 'framer-motion'
 // helpers
 import getMultipliers from './damage_multipliers'
-import { fadeInUpVariant } from '../../../helpers/animations'
+import { removeUnderscore, fadeInUpVariant } from '../../../helpers'
 // components
 import Loading from '../../Loading'
 import Box from '../../Box'
@@ -32,6 +32,7 @@ export default function Weaknesses({ ...rest }) {
       })
       // get multipliers
       const multipliers = getMultipliers(currTypes)
+      console.log(multipliers)
       // set state
       setMultipliers(multipliers)
       // initially show defense
@@ -58,10 +59,10 @@ export default function Weaknesses({ ...rest }) {
         <Switch enabled={enabled} onClick={() => setEnabled(!enabled)} />
       </Box>
       <AnimatePresence exitBeforeEnter>
-        {(pokemonInfo.isLoading || !typeMultipliers || !currMultipliers) && (
+        {(pokemonInfo.isLoading || !currMultipliers) && (
           <Loading height="251px" iconWidth="15%" key="pokemon-multipliers" />
         )}
-        {!pokemonInfo.isLoading && typeMultipliers && currMultipliers && (
+        {!pokemonInfo.isLoading && currMultipliers && (
           <Table
             initial="hidden"
             animate="show"
@@ -69,58 +70,22 @@ export default function Weaknesses({ ...rest }) {
             key={`pokemon-multipliers-table`}
           >
             <tbody>
-              <tr>
-                <th>{enabled ? 'Immune To' : 'No Effect To'}</th>
-                <td>
-                  {currMultipliers.no_damage.map((type, i) => (
-                    <TypeBadge key={`no-damage-${i}`} type={type} iconOnly />
-                  ))}
-                </td>
-              </tr>
-              <tr>
-                <th>0.25x</th>
-                <td>
-                  {currMultipliers.quarter_damage.map((type, i) => (
-                    <TypeBadge
-                      key={`quarter-damage-${i}`}
-                      type={type}
-                      iconOnly
-                    />
-                  ))}
-                </td>
-              </tr>
-              <tr>
-                <th>0.5x</th>
-                <td>
-                  {currMultipliers.half_damage.map((type, i) => (
-                    <TypeBadge key={`half-damage-${i}`} type={type} iconOnly />
-                  ))}
-                </td>
-              </tr>
-              <tr>
-                <th>2x</th>
-                <td>
-                  {currMultipliers.double_damage.map((type, i) => (
-                    <TypeBadge
-                      key={`double-damage-${i}`}
-                      type={type}
-                      iconOnly
-                    />
-                  ))}
-                </td>
-              </tr>
-              <tr>
-                <th>4x</th>
-                <td>
-                  {currMultipliers.quadruple_damage.map((type, i) => (
-                    <TypeBadge
-                      key={`quadruple-damage-${i}`}
-                      type={type}
-                      iconOnly
-                    />
-                  ))}
-                </td>
-              </tr>
+              {Object.keys(currMultipliers).map((relation, i) => (
+                <tr key={`type-relation-${i}`}>
+                  <th>{removeUnderscore(relation)}</th>
+                  <td>
+                    {!currMultipliers[relation].length
+                      ? 'None'
+                      : currMultipliers[relation].map((type, i) => (
+                          <TypeBadge
+                            key={`${type}-${relation}-${i}`}
+                            type={type}
+                            iconOnly
+                          />
+                        ))}
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </Table>
         )}

--- a/src/components/Pokemon/Multipliers/index.js
+++ b/src/components/Pokemon/Multipliers/index.js
@@ -32,7 +32,6 @@ export default function Weaknesses({ ...rest }) {
       })
       // get multipliers
       const multipliers = getMultipliers(currTypes)
-      console.log(multipliers)
       // set state
       setMultipliers(multipliers)
       // initially show defense

--- a/src/components/Type/Info/index.js
+++ b/src/components/Type/Info/index.js
@@ -1,9 +1,14 @@
+import styled from 'styled-components'
 // helpers
 import { mapGeneration, removeDash } from '../../../helpers'
 // components
 import Box from '../../Box'
 // styles
 import { Table } from '../../BaseStyles'
+
+const InfoTable = styled(Table)`
+  width: 100%;
+`
 
 export default function TypeInfo({ info, ...rest }) {
   console.log('info', info)
@@ -12,7 +17,7 @@ export default function TypeInfo({ info, ...rest }) {
 
   return (
     <Box {...rest}>
-      <Table>
+      <InfoTable>
         <tbody>
           <tr>
             <th>Type Id</th>
@@ -27,7 +32,7 @@ export default function TypeInfo({ info, ...rest }) {
             <td>{removeDash(move_damage_class.name)}</td>
           </tr>
         </tbody>
-      </Table>
+      </InfoTable>
     </Box>
   )
 }

--- a/src/components/Type/Info/index.js
+++ b/src/components/Type/Info/index.js
@@ -11,8 +11,6 @@ const InfoTable = styled(Table)`
 `
 
 export default function TypeInfo({ info, ...rest }) {
-  console.log('info', info)
-
   const { id, generation, move_damage_class } = info
 
   return (
@@ -23,14 +21,18 @@ export default function TypeInfo({ info, ...rest }) {
             <th>Type Id</th>
             <td>{`#${id}`}</td>
           </tr>
-          <tr>
-            <th>Generation</th>
-            <td>{mapGeneration(generation.name)}</td>
-          </tr>
-          <tr>
-            <th>Move Damage Class</th>
-            <td>{removeDash(move_damage_class.name)}</td>
-          </tr>
+          {generation && (
+            <tr>
+              <th>Generation</th>
+              <td>{mapGeneration(generation.name)}</td>
+            </tr>
+          )}
+          {move_damage_class && (
+            <tr>
+              <th>Move Damage Class</th>
+              <td>{removeDash(move_damage_class.name)}</td>
+            </tr>
+          )}
         </tbody>
       </InfoTable>
     </Box>

--- a/src/components/Type/Info/index.js
+++ b/src/components/Type/Info/index.js
@@ -1,0 +1,33 @@
+// helpers
+import { mapGeneration, removeDash } from '../../../helpers'
+// components
+import Box from '../../Box'
+// styles
+import { Table } from '../../BaseStyles'
+
+export default function TypeInfo({ info, ...rest }) {
+  console.log('info', info)
+
+  const { id, generation, move_damage_class } = info
+
+  return (
+    <Box {...rest}>
+      <Table>
+        <tbody>
+          <tr>
+            <th>Type Id</th>
+            <td>{`#${id}`}</td>
+          </tr>
+          <tr>
+            <th>Generation</th>
+            <td>{mapGeneration(generation.name)}</td>
+          </tr>
+          <tr>
+            <th>Move Damage Class</th>
+            <td>{removeDash(move_damage_class.name)}</td>
+          </tr>
+        </tbody>
+      </Table>
+    </Box>
+  )
+}

--- a/src/components/Type/Relations/index.js
+++ b/src/components/Type/Relations/index.js
@@ -1,7 +1,50 @@
+import styled, { css } from 'styled-components'
+// helpers
+import { removeUnderscore } from '../../../helpers'
 // components
 import Box from '../../Box'
+import TypeBadge from '../../TypeBadge'
+// styles
+import { Table, SectionTitle } from '../../BaseStyles'
+
+const RelationsTable = styled(Table)`
+  width: 100%;
+`
+
+const RelationTitle = styled(SectionTitle)`
+  ${({ theme }) => css`
+    @media ${theme.device.md} {
+      display: none;
+    }
+  `}
+`
 
 export default function TypeRelations({ relations, ...rest }) {
   console.log('relations: ', relations)
-  return <Box {...rest}>Relations</Box>
+
+  return (
+    <Box {...rest}>
+      <RelationTitle>Damage Relations</RelationTitle>
+      <RelationsTable>
+        <tbody>
+          {Object.keys(relations).map((relation, i) => (
+            <tr key={`type-relation-${i}`}>
+              <th>{removeUnderscore(relation)}</th>
+              <td>
+                {!relations[relation].length
+                  ? 'None'
+                  : relations[relation].map((type, i) => (
+                      <TypeBadge
+                        key={`${type.name}-${relation}-${i}`}
+                        type={type.name}
+                        iconOnly
+                      />
+                    ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </RelationsTable>
+    </Box>
+  )
 }

--- a/src/components/Type/Relations/index.js
+++ b/src/components/Type/Relations/index.js
@@ -1,0 +1,7 @@
+// components
+import Box from '../../Box'
+
+export default function TypeRelations({ relations, ...rest }) {
+  console.log('relations: ', relations)
+  return <Box {...rest}>Relations</Box>
+}

--- a/src/components/Type/Relations/index.js
+++ b/src/components/Type/Relations/index.js
@@ -20,8 +20,6 @@ const RelationTitle = styled(SectionTitle)`
 `
 
 export default function TypeRelations({ relations, ...rest }) {
-  console.log('relations: ', relations)
-
   return (
     <Box {...rest}>
       <RelationTitle>Damage Relations</RelationTitle>

--- a/src/components/Type/Tabs/Moves.js
+++ b/src/components/Type/Tabs/Moves.js
@@ -33,40 +33,44 @@ export default function Moves() {
         />
       )}
       {/** TABLE */}
-      <TableContainer>
-        <MovesTable>
-          <thead>
-            <tr>
-              <NameTH>Name</NameTH>
-              <th>Type</th>
-              <th>Category</th>
-              <th>Power</th>
-              <th>PP</th>
-              <th>Accuracy</th>
-              <th>Priority</th>
-              <th>Generation</th>
-            </tr>
-          </thead>
-          <TableBody>
-            {data.map((move, i) => (
-              <TableRow key={`type-${move.name}-${i}`}>
-                <NameTD>{removeDash(move.name)}</NameTD>
-                <td>
-                  <TypeBadge margin="0" iconOnly type={move.type.name} />
-                </td>
-                <td>
-                  {move.damage_class ? removeDash(move.damage_class.name) : '-'}
-                </td>
-                <td>{move.power || '-'}</td>
-                <td>{move.pp || '-'}</td>
-                <td>{move.accuracy || '-'}</td>
-                <td>{move.priority}</td>
-                <td>{mapGeneration(move.generation.name) || '-'}</td>
-              </TableRow>
-            ))}
-          </TableBody>
-        </MovesTable>
-      </TableContainer>
+      {!isLoading && data.length !== 0 && (
+        <TableContainer>
+          <MovesTable>
+            <thead>
+              <tr>
+                <NameTH>Name</NameTH>
+                <th>Type</th>
+                <th>Category</th>
+                <th>Power</th>
+                <th>PP</th>
+                <th>Accuracy</th>
+                <th>Priority</th>
+                <th>Generation</th>
+              </tr>
+            </thead>
+            <TableBody>
+              {data.map((move, i) => (
+                <TableRow key={`type-${move.name}-${i}`}>
+                  <NameTD>{removeDash(move.name)}</NameTD>
+                  <td>
+                    <TypeBadge margin="0" iconOnly type={move.type.name} />
+                  </td>
+                  <td>
+                    {move.damage_class
+                      ? removeDash(move.damage_class.name)
+                      : '-'}
+                  </td>
+                  <td>{move.power || '-'}</td>
+                  <td>{move.pp || '-'}</td>
+                  <td>{move.accuracy || '-'}</td>
+                  <td>{move.priority}</td>
+                  <td>{mapGeneration(move.generation.name) || '-'}</td>
+                </TableRow>
+              ))}
+            </TableBody>
+          </MovesTable>
+        </TableContainer>
+      )}
       {/** NO MOVES */}
       {!isLoading && data.length === 0 && (
         <SectionMessage

--- a/src/components/Type/TypeIcon/index.js
+++ b/src/components/Type/TypeIcon/index.js
@@ -1,0 +1,25 @@
+import React from 'react'
+// components
+import Box from '../../Box'
+import TypeBadge from '../../TypeBadge'
+// styles
+import { JpnName } from '../../BaseStyles'
+
+export default function TypeIcon({ typeName, otherNames, ...rest }) {
+  return (
+    <Box relative minHeight={{ xxs: '250px', lg: '350px' }} {...rest}>
+      <TypeBadge
+        type={typeName}
+        key={`type-icon-${typeName}`}
+        iconOnly
+        fill
+        float
+        iconWidth="auto"
+        iconHeight="150px"
+      />
+      <JpnName>
+        {otherNames.find(name => name.language.name === 'ja-Hrkt').name}
+      </JpnName>
+    </Box>
+  )
+}

--- a/src/components/Type/TypeIcon/index.js
+++ b/src/components/Type/TypeIcon/index.js
@@ -6,20 +6,21 @@ import TypeBadge from '../../TypeBadge'
 import { JpnName } from '../../BaseStyles'
 
 export default function TypeIcon({ typeName, otherNames, ...rest }) {
+  const japanName = otherNames.find(name => name.language.name === 'ja-Hrkt')
+    .name
+
   return (
     <Box relative minHeight={{ xxs: '250px', lg: '350px' }} {...rest}>
       <TypeBadge
         type={typeName}
         key={`type-icon-${typeName}`}
         iconOnly
-        fill
+        fill="true"
         float
         iconWidth="auto"
         iconHeight="150px"
       />
-      <JpnName>
-        {otherNames.find(name => name.language.name === 'ja-Hrkt').name}
-      </JpnName>
+      {japanName && <JpnName>{japanName}</JpnName>}
     </Box>
   )
 }

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -97,6 +97,8 @@ export default function Type() {
                 <PageHeading>{removeDash(name)}</PageHeading>
                 <Box
                   direction={{ xxs: 'column', md: 'row' }}
+                  justify={{ xxs: 'center', md: 'flex-start' }}
+                  align={{ xxs: 'center', md: 'flex-start' }}
                   sizes={{ xxs: 12, lg: 8 }}
                 >
                   <TypeInfo info={typeInfo.data} />

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -89,7 +89,6 @@ export default function Type() {
               align="flex-start"
               justify="flex-start"
               margin="1rem 0"
-              minHeight="347px"
             >
               <Box
                 justify={{ xxs: 'center', lg: 'flex-start' }}

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -103,8 +103,16 @@ export default function Type() {
                   align={{ xxs: 'center', md: 'flex-start' }}
                   sizes={{ xxs: 12, lg: 8 }}
                 >
-                  <TypeInfo info={typeInfo.data} />
-                  <TypeRelations relations={damage_relations} />
+                  <TypeInfo
+                    margin={{ xxs: '0 0 2rem', lg: '0' }}
+                    padding={{ xxs: '0', md: '0 1rem 0 0', lg: '0 0 0 2rem' }}
+                    info={typeInfo.data}
+                  />
+                  <TypeRelations
+                    margin={{ xxs: '0 0 2rem', lg: '0' }}
+                    padding={{ xxs: '0', md: '0 0 0 1rem', lg: '0 0 0 2rem' }}
+                    relations={damage_relations}
+                  />
                 </Box>
               </Box>
               <TypeIcon

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -59,6 +59,7 @@ export default function Type() {
       withHeader
       withFooter={!typeInfo.isLoading}
       withMain={false}
+      withGameVersion={false}
       key={`layout-type`}
     >
       <AnimatePresence exitBeforeEnter>

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -10,7 +10,11 @@ import { typeList, removeDash, pageContainerVariant } from '../../helpers'
 import Layout, { MainContainer } from '../Layout'
 import Loading from '../Loading'
 import Box from '../Box'
+import TypeInfo from './Info'
+import TypeRelations from './Relations'
 import Tabs from './Tabs'
+// styles
+import { PageHeading } from '../BaseStyles'
 
 export default function Type() {
   // router
@@ -19,6 +23,8 @@ export default function Type() {
   const dispatch = useDispatch()
   // type selector
   const typeInfo = useSelector(state => state.type)
+  // data
+  const { name, damage_relations } = typeInfo.data
 
   useEffect(() => {
     // reset data on unmount
@@ -51,7 +57,7 @@ export default function Type() {
     <Layout
       withHeader
       withFooter={!typeInfo.isLoading}
-      withMain={true}
+      withMain={false}
       key={`layout-type`}
     >
       <AnimatePresence exitBeforeEnter>
@@ -68,6 +74,7 @@ export default function Type() {
         {!typeInfo.isLoading && (
           <MainContainer
             justify="flex-start"
+            align="flex-start"
             constrained
             withGutter
             initial="hidden"
@@ -78,13 +85,26 @@ export default function Type() {
           >
             <Box
               as="section"
-              direction={{ xxs: 'column', lg: 'row' }}
+              direction={{ xxs: 'column-reverse', lg: 'row' }}
               align="flex-start"
               justify="flex-start"
               margin="1rem 0"
               minHeight="347px"
             >
-              Tables go here
+              <Box
+                justify={{ xxs: 'center', lg: 'flex-start' }}
+                align={{ xxs: 'center', lg: 'flex-start' }}
+              >
+                <PageHeading>{removeDash(name)}</PageHeading>
+                <Box
+                  direction={{ xxs: 'column', md: 'row' }}
+                  sizes={{ xxs: 12, lg: 8 }}
+                >
+                  <TypeInfo info={typeInfo.data} />
+                  <TypeRelations relations={damage_relations} />
+                </Box>
+              </Box>
+              <Box sizes={{ xxs: 12, lg: 4 }}>Icon</Box>
             </Box>
             <Box
               as="section"

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -105,12 +105,12 @@ export default function Type() {
                 >
                   <TypeInfo
                     margin={{ xxs: '0 0 2rem', lg: '0' }}
-                    padding={{ xxs: '0', md: '0 1rem 0 0', lg: '0 0 0 2rem' }}
+                    padding={{ xxs: '0', md: '0 1rem 0 0' }}
                     info={typeInfo.data}
                   />
                   <TypeRelations
                     margin={{ xxs: '0 0 2rem', lg: '0' }}
-                    padding={{ xxs: '0', md: '0 0 0 1rem', lg: '0 0 0 2rem' }}
+                    padding={{ xxs: '0', md: '0 0 0 1rem', lg: '0 1rem' }}
                     relations={damage_relations}
                   />
                 </Box>

--- a/src/components/Type/index.js
+++ b/src/components/Type/index.js
@@ -12,6 +12,7 @@ import Loading from '../Loading'
 import Box from '../Box'
 import TypeInfo from './Info'
 import TypeRelations from './Relations'
+import TypeIcon from './TypeIcon'
 import Tabs from './Tabs'
 // styles
 import { PageHeading } from '../BaseStyles'
@@ -24,7 +25,7 @@ export default function Type() {
   // type selector
   const typeInfo = useSelector(state => state.type)
   // data
-  const { name, damage_relations } = typeInfo.data
+  const { name, names, damage_relations } = typeInfo.data
 
   useEffect(() => {
     // reset data on unmount
@@ -105,7 +106,11 @@ export default function Type() {
                   <TypeRelations relations={damage_relations} />
                 </Box>
               </Box>
-              <Box sizes={{ xxs: 12, lg: 4 }}>Icon</Box>
+              <TypeIcon
+                sizes={{ xxs: 12, lg: 4 }}
+                typeName={name}
+                otherNames={names}
+              />
             </Box>
             <Box
               as="section"

--- a/src/components/TypeBadge/StyledBadge.js
+++ b/src/components/TypeBadge/StyledBadge.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components'
 import { motion } from 'framer-motion'
+// styles
+import { float as floatAnim } from '../BaseStyles'
 
 const Badge = styled(motion.a)`
   display: flex;
@@ -7,8 +9,8 @@ const Badge = styled(motion.a)`
   align-items: center;
   justify-content: center;
   width: auto;
-  background-color: ${({ theme, type }) =>
-    theme.typeBadge.backgroundColor[type]};
+  background-color: ${({ theme, type, fill }) =>
+    !fill && theme.typeBadge.backgroundColor[type]};
   color: ${({ theme }) => theme.typeBadge.color};
   font-family: 'Quicksand', sans-serif;
   font-size: 1rem;
@@ -35,21 +37,30 @@ const Badge = styled(motion.a)`
     }
   `}
 
+  ${({ float }) =>
+    float &&
+    css`
+      @media (prefers-reduced-motion: no-preference) {
+        animation: ${floatAnim} infinite 3s ease-in-out;
+      }
+    `}
+
   & svg {
-    ${({ iconOnly }) =>
+    ${({ iconOnly, iconWidth, iconHeight }) =>
       !iconOnly
         ? css`
-            width: 25px;
-            height: 25px;
+            width: ${iconWidth || '25px'};
+            height: ${iconHeight || '25px'};
             margin-right: 1rem;
           `
         : css`
-            width: 15px;
-            height: 15px;
+            width: ${iconWidth || '15px'};
+            height: ${iconHeight || '15px'};
           `}
 
     & > path {
-      fill: ${({ theme }) => theme.typeBadge.color};
+      fill: ${({ theme, type, fill }) =>
+        fill ? theme.typeBadge.backgroundColor[type] : theme.typeBadge.color};
       stroke: black;
       stroke-width: 5;
     }

--- a/src/helpers/typography.js
+++ b/src/helpers/typography.js
@@ -2,6 +2,7 @@
 export const capitalize = string =>
   string.charAt(0).toUpperCase() + string.slice(1)
 
+// remove underscores and replace with spaces
 export const removeUnderscore = string => {
   const words = string.split('_')
 
@@ -12,6 +13,7 @@ export const removeUnderscore = string => {
   return words.join(' ')
 }
 
+// remove dashes
 export const removeDash = string => {
   const words = string.split('-')
 


### PR DESCRIPTION
- Develops and Implements the top section on the `Type` page, including type info, damage relations, and type icon;
- Adds a prop to `Header` to dynamically hide the game version select;
- Refactors the `Multipliers` component in the `Pokemon` page in order to fix a bug where the incorrect icons were showing in the attack section.