### PR TITLE
Implements Pokestats Media

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,12 +17,12 @@ module.exports = {
       {
         protocol: 'https',
         hostname: 'raw.githubusercontent.com',
-        pathname: '/HybridShivam/Pokemon/**',
+        pathname: '/PokeAPI/sprites/**',
       },
       {
         protocol: 'https',
         hostname: 'raw.githubusercontent.com',
-        pathname: '/PokeAPI/sprites/**',
+        pathname: '/andreferreiradlw/pokestats_media/**',
       },
     ],
   },

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -148,7 +148,7 @@ const Autocomplete = ({
                 {assetType === 'type' && <TypeIcon type={name} />}
                 {assetType === 'pokemon' && (
                   <OptionImg
-                    src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${id
+                    src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${id
                       .toString()
                       .padStart(3, '0')}.png`}
                   />

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react';
 // helpers
-import { removeDash } from '@/helpers';
+import { removeDash, padPokemonId } from '@/helpers';
 // types
 import type { Pokemon, PokemonType } from '@/types';
 import type { BoxProps } from '@/components/Box';
@@ -148,9 +148,9 @@ const Autocomplete = ({
                 {assetType === 'type' && <TypeIcon type={name} />}
                 {assetType === 'pokemon' && (
                   <OptionImg
-                    src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${id
-                      .toString()
-                      .padStart(3, '0')}.png`}
+                    src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+                      id,
+                    )}.png`}
                   />
                 )}
                 <Option>{removeDash(name)}</Option>

--- a/src/components/Pokemon/FeatureImage/index.tsx
+++ b/src/components/Pokemon/FeatureImage/index.tsx
@@ -3,7 +3,7 @@ import type { Pokemon, PokemonSpecies } from 'pokenode-ts';
 import type { BoxProps } from '@/components/Box';
 import { useMemo } from 'react';
 // helpers
-import { scaleInVariant } from '@/helpers/animations';
+import { scaleInVariant, padPokemonId } from '@/helpers';
 // styles
 import { JpnName } from '@/components/BaseStyles';
 import { ImageContainer } from './StyledFeatureImage';
@@ -39,9 +39,9 @@ const FeaturedImage = ({
         loading="eager"
         placeholderwidth="20%"
         alt={englishName}
-        src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
-          .toString()
-          .padStart(3, '0')}.png`}
+        src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+          pokemonId,
+        )}.png`}
       />
       {specieNames && (
         <JpnName

--- a/src/components/Pokemon/FeatureImage/index.tsx
+++ b/src/components/Pokemon/FeatureImage/index.tsx
@@ -39,7 +39,7 @@ const FeaturedImage = ({
         loading="eager"
         placeholderwidth="20%"
         alt={englishName}
-        src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${pokemonId
+        src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
           .toString()
           .padStart(3, '0')}.png`}
       />

--- a/src/components/Pokemon/Moves/StyledMoves.ts
+++ b/src/components/Pokemon/Moves/StyledMoves.ts
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { motion } from 'framer-motion';
 // components
 import Box from '@/components/Box';
 
@@ -9,7 +10,7 @@ const NameTD = styled.td`
   text-transform: capitalize;
 `;
 
-const TableContainer = styled.div`
+const TableContainer = styled(motion.div)`
   overflow: auto;
   width: 100%;
 

--- a/src/components/Pokemon/Moves/index.tsx
+++ b/src/components/Pokemon/Moves/index.tsx
@@ -13,8 +13,10 @@ import {
   removeDash,
   fadeInUpVariant,
   getIdFromMove,
+  staggerTableVariant,
 } from '@/helpers';
 // components
+import { AnimatePresence } from 'framer-motion';
 import Box, { BoxProps } from '@/components/Box';
 import Loading from '@/components/Loading';
 import TypeBadge from '@/components/TypeBadge';
@@ -169,51 +171,65 @@ const PokemonMoves = ({ pokemon, ...rest }: PokemonMovesProps): JSX.Element => {
       {movesLoading && (
         <Loading flexheight="100%" $iconWidth={{ xxs: '20%', xs: '15%', md: '10%', lg: '5%' }} />
       )}
-      {genMoves?.[learnMethod]?.length ? (
-        <TableContainer>
-          <MovesTable>
-            <thead>
-              <tr>
-                <th>{mapMethodName(learnMethod)}</th>
-                <NameTH>Name</NameTH>
-                <th>Type</th>
-                <th>Category</th>
-                <th>Power</th>
-                <th>PP</th>
-                <th>Accuracy</th>
-                <th>Priority</th>
-                <th>Generation</th>
-              </tr>
-            </thead>
-            <TableBody>
-              {genMoves[learnMethod].map((move: PokemonMove, i: number) => (
-                <TableRow key={`${learnMethod}-${move.name}-${i}`}>
-                  {/* @ts-ignore **/}
-                  {learnMethod === 'level-up' && <td>{move.level_learned_at}</td>}
-                  {learnMethod === 'machine' &&
-                    (machineNames?.[i] ? <td>{machineNames[i].toUpperCase()}</td> : <td>...</td>)}
-                  {learnMethod === 'egg' && <td>-</td>}
-                  {learnMethod === 'tutor' && <td>-</td>}
-                  <NameTD>{removeDash(move.name)}</NameTD>
-                  <td>
-                    <TypeBadge flexmargin="0" $iconOnly $typename={move.type.name} />
-                  </td>
-                  <UppercasedTd>{move.damage_class.name}</UppercasedTd>
-                  <td>{move.power || '-'}</td>
-                  <td>{move.pp || '-'}</td>
-                  <td>{move.accuracy || '-'}</td>
-                  <td>{move.priority}</td>
-                  <td>{mapGeneration(move.generation.name)}</td>
-                </TableRow>
-              ))}
-            </TableBody>
-          </MovesTable>
-        </TableContainer>
-      ) : (
-        <SectionMessage>
-          {`No ${learnMethod} moves for currently selected game version.`}
-        </SectionMessage>
-      )}
+      <AnimatePresence mode="wait">
+        {genMoves?.[learnMethod]?.length ? (
+          <TableContainer
+            initial="hidden"
+            animate="show"
+            exit="exit"
+            variants={fadeInUpVariant}
+            key={`moves-${learnMethod}-table-container`}
+          >
+            <MovesTable>
+              <thead>
+                <tr>
+                  <th>{mapMethodName(learnMethod)}</th>
+                  <NameTH>Name</NameTH>
+                  <th>Type</th>
+                  <th>Category</th>
+                  <th>Power</th>
+                  <th>PP</th>
+                  <th>Accuracy</th>
+                  <th>Priority</th>
+                  <th>Generation</th>
+                </tr>
+              </thead>
+              <TableBody>
+                {genMoves[learnMethod].map((move: PokemonMove, i: number) => (
+                  <TableRow key={`${learnMethod}-${move.name}-${i}`}>
+                    {/* @ts-ignore **/}
+                    {learnMethod === 'level-up' && <td>{move.level_learned_at}</td>}
+                    {learnMethod === 'machine' &&
+                      (machineNames?.[i] ? <td>{machineNames[i].toUpperCase()}</td> : <td>...</td>)}
+                    {learnMethod === 'egg' && <td>-</td>}
+                    {learnMethod === 'tutor' && <td>-</td>}
+                    <NameTD>{removeDash(move.name)}</NameTD>
+                    <td>
+                      <TypeBadge flexmargin="0" $iconOnly $typename={move.type.name} />
+                    </td>
+                    <UppercasedTd>{move.damage_class.name}</UppercasedTd>
+                    <td>{move.power || '-'}</td>
+                    <td>{move.pp || '-'}</td>
+                    <td>{move.accuracy || '-'}</td>
+                    <td>{move.priority}</td>
+                    <td>{mapGeneration(move.generation.name)}</td>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </MovesTable>
+          </TableContainer>
+        ) : (
+          <SectionMessage
+            initial="hidden"
+            animate="show"
+            exit="exit"
+            variants={fadeInUpVariant}
+            key={`moves-${learnMethod}-nomoves-message`}
+          >
+            {`No ${learnMethod} moves for currently selected game version.`}
+          </SectionMessage>
+        )}
+      </AnimatePresence>
     </Box>
   );
 };

--- a/src/components/Pokemon/Navigation/index.tsx
+++ b/src/components/Pokemon/Navigation/index.tsx
@@ -2,7 +2,7 @@
 import type { PokestatsPokemonPageProps } from '@/pages/pokemon/[pokemonId]';
 import type { Pokemon } from 'pokenode-ts';
 // helpers
-import { removeDash, fadeInUpVariant } from '@/helpers';
+import { removeDash, fadeInUpVariant, padPokemonId } from '@/helpers';
 // styles
 import { BtnContainer, BtnAnchor, Title, Arrow, PokemonID, PokemonName } from './StyledNavigation';
 // components
@@ -48,11 +48,9 @@ const Navigation = ({ allPokemon, pokemonId, ...rest }: NavigationProps): JSX.El
           >
             <Arrow $left>
               <ImageNext
-                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${(
-                  pokemonId - 1
-                )
-                  .toString()
-                  .padStart(3, '0')}.png`}
+                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+                  pokemonId - 1,
+                )}.png`}
                 alt={allPokemon[pokemonId - 2].name}
                 key={`navigation-left-${allPokemon[pokemonId - 2].name}`}
                 width="100"
@@ -76,11 +74,9 @@ const Navigation = ({ allPokemon, pokemonId, ...rest }: NavigationProps): JSX.El
           <BtnAnchor href={`/pokemon/${allPokemon[pokemonId].name}`} onClick={nextPokemon} $right>
             <Arrow $right>
               <ImageNext
-                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${(
-                  pokemonId + 1
-                )
-                  .toString()
-                  .padStart(3, '0')}.png`}
+                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+                  pokemonId + 1,
+                )}.png`}
                 alt={allPokemon[pokemonId].name}
                 key={`navigation-right-${allPokemon[pokemonId].name}`}
                 width="100"

--- a/src/components/Pokemon/Navigation/index.tsx
+++ b/src/components/Pokemon/Navigation/index.tsx
@@ -48,7 +48,7 @@ const Navigation = ({ allPokemon, pokemonId, ...rest }: NavigationProps): JSX.El
           >
             <Arrow $left>
               <ImageNext
-                src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${(
+                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${(
                   pokemonId - 1
                 )
                   .toString()
@@ -76,7 +76,7 @@ const Navigation = ({ allPokemon, pokemonId, ...rest }: NavigationProps): JSX.El
           <BtnAnchor href={`/pokemon/${allPokemon[pokemonId].name}`} onClick={nextPokemon} $right>
             <Arrow $right>
               <ImageNext
-                src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${(
+                src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${(
                   pokemonId + 1
                 )
                   .toString()

--- a/src/components/Pokemon/Sprites/index.tsx
+++ b/src/components/Pokemon/Sprites/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 // types
 import type { Pokemon, PokemonSpecies, PokemonSprites } from 'pokenode-ts';
 // helpers
-import { removeUnderscore } from '@/helpers/typography';
+import { removeUnderscore, padPokemonId } from '@/helpers';
 // styles
 import { SectionTitle, SectionSubTitle } from '@/components/BaseStyles';
 import { SpriteContainer, Sprite, SpriteSubtitle, NoSprites } from './StyledSprites';
@@ -154,9 +154,9 @@ const Sprites = ({ pokemonSprites, pokemonId, forms, ...rest }: SpritesProps): J
                     <Sprite
                       alt="Official Artwork Front Default"
                       key="official-artwork"
-                      src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
-                        .toString()
-                        .padStart(3, '0')}-${name}.png`}
+                      src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+                        pokemonId,
+                      )}-${name}.png`}
                       height="180"
                     />
                   </SpriteContainer>

--- a/src/components/Pokemon/Sprites/index.tsx
+++ b/src/components/Pokemon/Sprites/index.tsx
@@ -154,7 +154,7 @@ const Sprites = ({ pokemonSprites, pokemonId, forms, ...rest }: SpritesProps): J
                     <Sprite
                       alt="Official Artwork Front Default"
                       key="official-artwork"
-                      src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${pokemonId
+                      src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
                         .toString()
                         .padStart(3, '0')}-${name}.png`}
                       height="180"

--- a/src/components/PokemonBox/index.tsx
+++ b/src/components/PokemonBox/index.tsx
@@ -38,7 +38,7 @@ const PokemonBox = forwardRef(
           <ImageNext
             alt={pokemonName}
             key={`pokemonbox-img-${pokemonId}`}
-            src={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${pokemonId
+            src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
               .toString()
               .padStart(3, '0')}.png`}
             width="100"

--- a/src/components/PokemonBox/index.tsx
+++ b/src/components/PokemonBox/index.tsx
@@ -1,9 +1,9 @@
-import { CSSProperties, useMemo, forwardRef, Ref } from 'react';
+import { useMemo, forwardRef, Ref } from 'react';
 // types
 import type { Pokemon, PokemonSpecies } from 'pokenode-ts';
 import type { HTMLMotionProps } from 'framer-motion';
 // helpers
-import { removeDash, mapGeneration, fadeInUpVariant } from '@/helpers';
+import { removeDash, mapGeneration, fadeInUpVariant, padPokemonId } from '@/helpers';
 // styles
 import { PokeBox, NumberId, PokeName, PokeGen } from './StyledPokemonBox';
 // components
@@ -38,9 +38,9 @@ const PokemonBox = forwardRef(
           <ImageNext
             alt={pokemonName}
             key={`pokemonbox-img-${pokemonId}`}
-            src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${pokemonId
-              .toString()
-              .padStart(3, '0')}.png`}
+            src={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+              pokemonId,
+            )}.png`}
             width="100"
             height="100"
           />

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -12,8 +12,6 @@ export * from './moves';
 export * from './random';
 // refs
 export * from './refs';
-// strings
-export * from './string';
 // typography
 export * from './typography';
 // id

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -1,9 +1,0 @@
-const formatFlavorText = (text: string): string =>
-  text
-    .replace(/\u00AD/g, '')
-    .replace(/\u000C/g, ' ')
-    .replace(/u' -\n'/, ' - ')
-    .replace(/u'-\n'/, '-')
-    .replace(/(\r\n|\n|\r)/gm, ' ');
-
-export { formatFlavorText };

--- a/src/helpers/typography.ts
+++ b/src/helpers/typography.ts
@@ -4,4 +4,14 @@ const removeUnderscore = (str: string): string => str.replace(/_/g, ' ');
 // remove dashes
 const removeDash = (str: string): string => str.replace(/-/g, ' ');
 
-export { removeUnderscore, removeDash };
+const formatFlavorText = (text: string): string =>
+  text
+    .replace(/\u00AD/g, '')
+    .replace(/\u000C/g, ' ')
+    .replace(/u' -\n'/, ' - ')
+    .replace(/u'-\n'/, '-')
+    .replace(/(\r\n|\n|\r)/gm, ' ');
+
+const padPokemonId = (id: number): string => id.toString().padStart(3, '0');
+
+export { removeUnderscore, removeDash, formatFlavorText, padPokemonId };

--- a/src/pages/pokemon/[pokemonId].tsx
+++ b/src/pages/pokemon/[pokemonId].tsx
@@ -16,7 +16,7 @@ import {
   getIdFromEvolutionChain,
   getIdFromSpecies,
   mapGenerationToGame,
-  removeDash,
+  padPokemonId,
   formatFlavorText,
   gameVersions,
   findPokemonName,
@@ -91,9 +91,9 @@ const PokestatsPokemonPage: NextPage<PokestatsPokemonPageProps> = ({
         <meta property="og:description" content={pageDescription} />
         <meta
           property="og:image"
-          content={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${props.pokemon.id
-            .toString()
-            .padStart(3, '0')}.png`}
+          content={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${padPokemonId(
+            props.pokemon.id,
+          )}.png`}
         />
       </Head>
       <Layout

--- a/src/pages/pokemon/[pokemonId].tsx
+++ b/src/pages/pokemon/[pokemonId].tsx
@@ -91,7 +91,7 @@ const PokestatsPokemonPage: NextPage<PokestatsPokemonPageProps> = ({
         <meta property="og:description" content={pageDescription} />
         <meta
           property="og:image"
-          content={`https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${props.pokemon.id
+          content={`https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/images/${props.pokemon.id
             .toString()
             .padStart(3, '0')}.png`}
         />


### PR DESCRIPTION
This PR updates images `src` values to fetch images from the new `andreferreiradlw/pokestats_media` repository.

Also creates the new `padPokemonId` helper to make sure pokemon `id`s used in the `url` are at least 3 digits long.