### PR TITLE
Prefetch Random Pokemon Page

### DIFF
--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { AnimatePresence } from 'framer-motion';
 // heplpers
-import { staggerInitialVariant, fadeInUpVariant } from '@/helpers';
+import { staggerInitialVariant, fadeInUpVariant, getRandomInt } from '@/helpers';
 // types
 import type { PokestatsHomepageProps } from '@/pages/index';
 // styles
@@ -21,7 +21,7 @@ const Homepage = ({ allPokemon, pokemonTypes }: PokestatsHomepageProps): JSX.Ele
   const router = useRouter();
   // memo
   const randomPokemonUrl = useMemo(
-    () => `/pokemon/${allPokemon[Math.floor(Math.random() * allPokemon.length)].name}`,
+    () => `/pokemon/${allPokemon[getRandomInt(1, allPokemon.length)].name}`,
     [allPokemon],
   );
   // prefetch random pokemon page

--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -1,10 +1,10 @@
+import { useMemo, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { AnimatePresence } from 'framer-motion';
 // heplpers
 import { staggerInitialVariant, fadeInUpVariant } from '@/helpers';
 // types
 import type { PokestatsHomepageProps } from '@/pages/index';
-import type { Pokemon, PokemonType } from '@/types';
 // styles
 import { Container, GithubLink, ScrollDown, ListContainer } from './styledHomepage';
 import { MainHeading, Button } from '@/components/BaseStyles';
@@ -19,11 +19,20 @@ import Github from 'public/static/iconLibrary/github.svg';
 const Homepage = ({ allPokemon, pokemonTypes }: PokestatsHomepageProps): JSX.Element => {
   // router
   const router = useRouter();
+  // memo
+  const randomPokemonUrl = useMemo(
+    () => `/pokemon/${allPokemon[Math.floor(Math.random() * allPokemon.length)].name}`,
+    [allPokemon],
+  );
+  // prefetch random pokemon page
+  useEffect(() => {
+    if (router && randomPokemonUrl) router.prefetch(randomPokemonUrl);
+  }, [randomPokemonUrl, router]);
 
   const routeRandom = () => {
     if (process.env.NODE_ENV === 'production' && window?.plausible)
       window.plausible('Random Pokemon');
-    router.push(`/pokemon/${allPokemon[Math.floor(Math.random() * allPokemon.length)].name}`);
+    router.push(randomPokemonUrl);
   };
 
   const githubClick = () => {

--- a/src/components/Pokemon/Breeding/index.tsx
+++ b/src/components/Pokemon/Breeding/index.tsx
@@ -26,7 +26,7 @@ interface BreedingProps extends BoxProps {
 
 const Breeding = ({ species, babyTriggerItem, ...rest }: BreedingProps): JSX.Element => {
   // data
-  const { gender_rate, egg_groups, hatch_counter, habitat } = species;
+  const { gender_rate, egg_groups, hatch_counter, habitat, growth_rate } = species;
   // memo
   const genderRatio = useMemo(
     () => (
@@ -43,9 +43,9 @@ const Breeding = ({ species, babyTriggerItem, ...rest }: BreedingProps): JSX.Ele
     () =>
       egg_groups?.map((group, i) => (
         <Numbered key={`${group.name}-${i}`}>
-          <UppercasedTd as="p">{`${egg_groups.length > 1 ? `${i + 1}. ` : ``}${
-            group.name
-          }`}</UppercasedTd>
+          <UppercasedTd as="p">{`${egg_groups.length > 1 ? `${i + 1}. ` : ``}${removeDash(
+            group.name,
+          )}`}</UppercasedTd>
         </Numbered>
       )),
     [egg_groups],
@@ -68,6 +68,10 @@ const Breeding = ({ species, babyTriggerItem, ...rest }: BreedingProps): JSX.Ele
           <tr>
             <th>Gender Distribution</th>
             <td>{gender_rate === -1 ? 'Genderless' : genderRatio}</td>
+          </tr>
+          <tr>
+            <th>Growth Rate</th>
+            <UppercasedTd>{removeDash(growth_rate.name)}</UppercasedTd>
           </tr>
           <tr>
             <th>Egg Groups</th>

--- a/src/components/Pokemon/Training/index.tsx
+++ b/src/components/Pokemon/Training/index.tsx
@@ -19,7 +19,7 @@ const Training = ({ pokemon, species, ...rest }: TrainingProps): JSX.Element => 
   const { gameVersion } = useContext(GameVersionContext);
   // data
   const { stats, base_experience, held_items } = pokemon;
-  const { capture_rate, base_happiness, growth_rate } = species;
+  const { capture_rate, base_happiness } = species;
   // held items
   const [items, setItems] = useState([]);
   // memo
@@ -103,10 +103,6 @@ const Training = ({ pokemon, species, ...rest }: TrainingProps): JSX.Element => 
           <tr>
             <th>Base Exp.</th>
             <td>{base_experience}</td>
-          </tr>
-          <tr>
-            <th>Growth Rate</th>
-            <UppercasedTd>{removeDash(growth_rate.name)}</UppercasedTd>
           </tr>
           <tr>
             <th>Held Items</th>


### PR DESCRIPTION
This PR prefetches the data for the generated random pokemon url, making the routing a lot faster when the button is clicked on the homepage.

Also moves the `growth rate` data on the pokemon page from the training to the breeding section.