### PR TITLE
Adds support for Gen VIII Pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,14 @@
 ✅ Pokemon Page <br />
 ✅ Type Page <br />
 ✅ Static Generated Pages <br />
-🚫 Generation 8 Pokemon Ready (waiting on [PokéApi's issue](https://github.com/PokeAPI/pokeapi/issues/520)) <br />
+✅ Generation 8 Pokemon ([some data is incomplete](https://github.com/PokeAPI/pokeapi/issues/520)) <br />
 ✅ Typescript Refactoring <br />
 🛠️ [Move Page](https://pokeapi.api-docs.io/v2.0/moves/rNQ5oSyuW7AJ3mqEe) <br />
-🗒️ [Headbutt Tree Encounters](https://bulbapedia.bulbagarden.net/wiki/Headbutt_tree) <br />
-🗒️ Unit Tests <br />
-🗒️ Dark Mode <br />
+🗒️ [Encounters](https://pokeapi.api-docs.io/v2.0/encounters) & [Item](https://pokeapi.api-docs.io/v2.0/locations/h6KztxeJv67pvfT5F) Map <br />
+🗒️ [Headbutt Tree Encounters](https://bulbapedia.bulbagarden.net/wiki/Headbutt_tree) Map <br />
 🗒️ [Item Page](https://pokeapi.api-docs.io/v2.0/items/kBoBXQHp45mFi4oNb) <br />
 🗒️ [Berry Page](https://pokeapi.api-docs.io/v2.0/berries/pHc3vWdv6Pkyk377Q) <br />
-💡 [Encounters](https://pokeapi.api-docs.io/v2.0/encounters) & [Item](https://pokeapi.api-docs.io/v2.0/locations/h6KztxeJv67pvfT5F) Locations Map <br />
+🗒️ Dark Mode <br />
 
 ## Contributing
 
@@ -86,7 +85,11 @@ Checkout [CONTRIBUTING.md](https://github.com/andreferreiradlw/pokestats/blob/ma
 
 ## Aknowledgements
 
-Thanks to [PokéApi](https://pokeapi.co) for the data and images (without it, this project would not be possible), [Naramsim](https://github.com/Naramsim) for the images [service worker](https://github.com/PokeAPI/pokeapi-js-wrapper#caching-images) and [duiker101](https://github.com/duiker101/pokemon-type-svg-icons) for the great SVG Type Icons.
+[PokéApi](https://pokeapi.co) for the data and images (without it, this project would not be possible),
+[duiker101](https://github.com/duiker101/pokemon-type-svg-icons) for the great SVG Type Icons,
+[Gabb-c](https://github.com/Gabb-c/pokenode-ts) for the NodeJS wrapper with Typescript support,
+[msikma](https://github.com/msikma/pokesprite) for all the item sprites,
+[HybridShivam](https://github.com/HybridShivam/Pokemon) for the compressed images for each Pokemon and their varieties
 
 ## License
 
@@ -96,11 +99,11 @@ MIT
 
 This is an unofficial, non-commercial, fan-made app and is NOT affiliated, endorsed or supported by Nintendo, Game Freak and The Pokémon Company in any way.
 The images used are © Nintendo/Creatures and Inc./GAME FREAK Inc. Pokémon and Pokémon character names are trademarks of Nintendo.
-Everything else, and the programming code, is governed by the MIT license.
+Everything else, including the code, is governed by the MIT license.
 
 ## Donate
 
-Please consider donating if you think pokestats is helpful to you and want to support the project ❤️
+Please consider donating if you think pokestats is helpful to you and want to see the project evolve ❤️
 
 <a href="https://www.buymeacoffee.com/pokestats">
   <img alt="bmc-button" src="https://img.shields.io/badge/Buy_Me_A_Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black">

--- a/src/components/Autocomplete/index.tsx
+++ b/src/components/Autocomplete/index.tsx
@@ -117,7 +117,7 @@ const Autocomplete = ({ filterList, ...rest }: AutocompleteProps): JSX.Element =
       <Input
         type="text"
         autoComplete="off"
-        placeholder="Search PokeStats"
+        placeholder="Search PokeStats..."
         id="autocomplete"
         aria-labelledby="autocomplete_label"
         value={search}

--- a/src/components/Autocomplete/styledAutoComplete.ts
+++ b/src/components/Autocomplete/styledAutoComplete.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 // types
 import type { AutocompleteProps } from './index';
+import { focusStyles } from '@/BaseStyles';
 // components
 import { motion } from 'framer-motion';
 import Link from 'next/link';
@@ -19,10 +20,13 @@ const Container = styled(motion.div)<{ width?: AutocompleteProps['width'] }>`
 
           @media ${theme.device.sm} {
             max-width: 650px;
-            width: 75%;
+            width: 55%;
+          }
+          @media ${theme.device.md} {
+            width: 40%;
           }
           @media ${theme.device.lg} {
-            width: 55%;
+            width: 30%;
           }
         `}
 
@@ -41,23 +45,23 @@ const Container = styled(motion.div)<{ width?: AutocompleteProps['width'] }>`
 
 const Input = styled.input<{ $isOpen: Boolean }>`
   font-size: 1em;
-  font-weight: 400;
-  line-height: 1;
+  font-weight: 500;
   max-width: 100%;
-  outline: none;
   padding: 0.5rem 0.75rem;
-  position: relative;
   width: 100%;
 
   ${({ theme, $isOpen }) => css`
-    background-color: ${theme.colors.secondary.main};
-    border: ${theme.colors.secondary.main};
+    background-color: ${theme.colors.primary.main};
+    border: 2px solid ${theme.colors.secondary.main};
     border-radius: ${$isOpen ? '0.25rem 0.25rem 0 0' : '0.25rem'};
-    color: ${theme.colors.secondary.contrastText};
+    color: ${theme.colors.primary.contrastText};
 
     &::placeholder {
-      color: ${theme.colors.secondary.contrastText};
+      color: ${theme.colors.secondary.light};
+      font-style: italic;
     }
+
+    ${focusStyles}
 
     @media ${theme.device.md} {
       font-size: 1em;
@@ -121,13 +125,13 @@ const OptionWrapper = styled(Link)`
 
 const Option = styled.span`
   font-size: 1.3em;
-  font-weight: 600;
+  font-weight: 500;
   text-transform: capitalize;
 `;
 
 const PokeID = styled(Option)`
   font-size: 1.5em;
-  font-weight: 600;
+  font-weight: 500;
 `;
 
 export { Container, Input, ListWrapper, OptionWrapper, OptionImg, Option, PokeID };

--- a/src/components/BaseStyles/button.ts
+++ b/src/components/BaseStyles/button.ts
@@ -2,6 +2,16 @@ import styled, { css } from 'styled-components';
 import { motion } from 'framer-motion';
 import type { ThemeType } from '../Theme/theme';
 
+const focusStyles = css`
+  ${({ theme }) => css`
+    &:focus,
+    &:focus-visible {
+      outline: ${theme.colors.tertiary.main} auto 1px;
+      outline-offset: 2px;
+    }
+  `}
+`;
+
 const darkValues = (theme: ThemeType) => css`
   background-color: ${theme.colors.secondary.main};
   border: 2px solid ${theme.colors.secondary.main};
@@ -44,11 +54,11 @@ const Button = styled(motion.button)<{ $dark?: boolean; $active?: boolean }>`
   cursor: pointer;
   font-size: 1em;
   font-weight: 500;
-  line-height: 1;
-  outline: none;
   padding: 10px 20px;
   text-align: center;
   transition: box-shadow 0.2s ease-in-out;
+
+  ${focusStyles}
 
   ${({ $active, $dark, theme }) =>
     $dark
@@ -60,4 +70,4 @@ const Button = styled(motion.button)<{ $dark?: boolean; $active?: boolean }>`
       : lightValues(theme)}
 `;
 
-export { Button };
+export { Button, focusStyles };

--- a/src/components/BaseStyles/headings.ts
+++ b/src/components/BaseStyles/headings.ts
@@ -4,16 +4,22 @@ import { motion } from 'framer-motion';
 const MainHeading = styled(motion.h1)`
   color: ${({ theme }) => theme.colors.white};
   font-family: 'Josefin Sans', sans-serif;
-  font-size: 3.5em;
+  font-size: 3em;
   font-weight: 700;
   text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;
   user-select: none;
 
   ${({ theme }) => css`
     @media ${theme.device.xs} {
-      font-size: 5rem;
+      font-size: 4.2rem;
+    }
+    @media ${theme.device.sm} {
+      font-size: 6em;
     }
     @media ${theme.device.md} {
+      font-size: 7.5em;
+    }
+    @media ${theme.device.lg} {
       font-size: 10em;
     }
   `}

--- a/src/components/Dropdown/StyledDropdown.ts
+++ b/src/components/Dropdown/StyledDropdown.ts
@@ -1,6 +1,8 @@
 import styled, { css } from 'styled-components';
 // types
 import type { DropdownProps } from './index';
+// styles
+import { focusStyles } from '@/BaseStyles';
 // components
 import Box from '@/components/Box';
 // icons
@@ -45,6 +47,8 @@ const SelectButton = styled.button<{ $isOpen: Boolean }>`
     border: 2px solid ${theme.colors.secondary.main};
     color: ${theme.colors.primary.contrastText};
   `}
+
+  ${focusStyles}
 
   ${({ $isOpen }) =>
     css`

--- a/src/components/Homepage/styledHomepage.ts
+++ b/src/components/Homepage/styledHomepage.ts
@@ -14,6 +14,7 @@ const Container = styled(BoxWrapper)`
   margin: auto;
   min-height: 50vh;
   position: relative;
+  width: 100%;
   z-index: 1;
 `;
 

--- a/src/components/Pokemon/Details/index.tsx
+++ b/src/components/Pokemon/Details/index.tsx
@@ -58,14 +58,16 @@ const PokemonDetails = ({
   // load pokemon cry sound
   const [cry, setCry] = useState(null);
   useEffect(() => {
-    setCry(
-      new Audio(
-        `https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/cries/${id}.${
-          id >= 722 ? 'wav' : 'mp3'
-        }`,
-      ),
-    );
-  }, []);
+    if (id <= 802) {
+      setCry(
+        new Audio(
+          `https://raw.githubusercontent.com/andreferreiradlw/pokestats_media/main/assets/cries/${id}.${
+            id >= 722 ? 'wav' : 'mp3'
+          }`,
+        ),
+      );
+    }
+  }, [id]);
   const generationName = useMemo(() => mapGeneration(generation?.name), [generation]);
   const flavorText = useMemo(() => {
     // @ts-ignore

--- a/src/components/Pokemon/EvolutionChain/Evolution/index.tsx
+++ b/src/components/Pokemon/EvolutionChain/Evolution/index.tsx
@@ -21,7 +21,7 @@ const Evolution = ({
   ...rest
 }: EvolutionProps): JSX.Element => {
   // data
-  const { id, name, generation } = species;
+  const { id, name, generation, varieties } = species;
 
   const pokemonName = findPokemonName(species);
 
@@ -49,6 +49,7 @@ const Evolution = ({
         pokemonGen={generation?.name}
         nameFormat={false}
         pokemonName={pokemonName}
+        defaultVarietyName={varieties[0].pokemon.name}
       />
     </EvolutionContainer>
   );

--- a/src/components/Pokemon/Forms/index.tsx
+++ b/src/components/Pokemon/Forms/index.tsx
@@ -31,9 +31,9 @@ const PokemonForms = ({
         const varietyName = removeDash(form.pokemon.name);
         return (
           <Numbered key={`${form.pokemon.name}-${i}`}>
-            {`${varieties.length > 1 ? `${i + 1}. ` : ``}${
-              i === 0 ? pokemonName : varietyName.substring(varietyName.indexOf(' ') + 1)
-            }`}
+            {`${varieties.length > 1 ? `${i + 1}. ` : ``}${varietyName.substring(
+              varietyName.indexOf(' ') + 1,
+            )}`}
             {form.is_default && <span>{` (Default)`}</span>}
           </Numbered>
         );

--- a/src/components/Pokemon/Moves/index.tsx
+++ b/src/components/Pokemon/Moves/index.tsx
@@ -82,6 +82,11 @@ const PokemonMoves = ({ pokemon, ...rest }: PokemonMovesProps): JSX.Element => {
   }, []);
 
   useEffect(() => {
+    // console.log(pokemon);
+    // console.log('genMoves', genMoves);
+  }, [genMoves]);
+
+  useEffect(() => {
     if (!movesLoading) setMovesLoading(true);
 
     const moveClient = new MoveClient();
@@ -208,7 +213,7 @@ const PokemonMoves = ({ pokemon, ...rest }: PokemonMovesProps): JSX.Element => {
                             <span>{machineNames[i].toUpperCase()}</span>
                             <img
                               src={`https://raw.githubusercontent.com/msikma/pokesprite/master/items/${
-                                machineNames[i].includes('tm') ? 'tm' : 'hm'
+                                machineNames[i].includes('hm') ? 'hm' : 'tm'
                               }/${move.type.name}.png`}
                               alt={move.type.name}
                               width="30"

--- a/src/components/Pokemon/Sprites/StyledSprites.ts
+++ b/src/components/Pokemon/Sprites/StyledSprites.ts
@@ -11,14 +11,10 @@ const SpriteContainer = styled(Box)`
 
 const Sprite = styled(ImageNext)``;
 
-const SpriteSubtitle = styled(SectionSubTitle)`
-  text-align: center;
-`;
-
 const NoSprites = styled(Box)`
   font-size: 2rem;
   line-height: 2.5rem;
   text-align: center;
 `;
 
-export { SpriteContainer, Sprite, SpriteSubtitle, NoSprites };
+export { SpriteContainer, Sprite, NoSprites };

--- a/src/components/Pokemon/Sprites/index.tsx
+++ b/src/components/Pokemon/Sprites/index.tsx
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 // types
 import type { Pokemon, PokemonSpecies, PokemonSprites } from 'pokenode-ts';
 // helpers
-import { removeUnderscore, prefixId } from '@/helpers';
+import { removeUnderscore, prefixId, capitalise, removeDash } from '@/helpers';
 // styles
-import { SectionTitle, SectionSubTitle, Divider } from '@/components/BaseStyles';
-import { SpriteContainer, Sprite, SpriteSubtitle, NoSprites } from './StyledSprites';
+import { SectionTitle, Divider } from '@/components/BaseStyles';
+import { SpriteContainer, Sprite, NoSprites } from './StyledSprites';
 // components
 import Box, { BoxProps } from '@/components/Box';
 
@@ -20,6 +20,11 @@ const Sprites = ({ pokemonSprites, pokemonId, forms, ...rest }: SpritesProps): J
   const animatedSprites = pokemonSprites.versions['generation-v']['black-white'].animated;
   const dreamWorldSprites = pokemonSprites.other.dream_world;
   const officalArtworkSprites = pokemonSprites.other['official-artwork'];
+
+  const defaultVarietyName = useMemo(() => {
+    const defaultForm = removeDash(forms.find(form => form.is_default).pokemon.name);
+    return capitalise(defaultForm.substring(defaultForm.indexOf(' ') + 1));
+  }, [forms]);
 
   const alternativeForms = useMemo(
     () =>
@@ -122,7 +127,7 @@ const Sprites = ({ pokemonSprites, pokemonId, forms, ...rest }: SpritesProps): J
                     height="180"
                   />
                 </SpriteContainer>
-                <p>Official</p>
+                <p>{defaultVarietyName}</p>
               </Box>
             )}
             {(dreamWorldSprites.front_default || dreamWorldSprites.front_female) && (

--- a/src/components/Pokemon/Training/index.tsx
+++ b/src/components/Pokemon/Training/index.tsx
@@ -102,19 +102,19 @@ const Training = ({ pokemon, species, ...rest }: TrainingProps): JSX.Element => 
         <tbody>
           <tr>
             <th>EV Yield</th>
-            <td>{EVYield}</td>
+            <td>{stats?.length ? EVYield : 'Not available'}</td>
           </tr>
           <tr>
             <th>Catch Rate</th>
-            <td>{catchRate}</td>
+            <td>{capture_rate ? catchRate : 'Not available'}</td>
           </tr>
           <tr>
             <th>Base Happiness</th>
-            <td>{baseHappiness}</td>
+            <td>{base_happiness ? baseHappiness : 'Not available'}</td>
           </tr>
           <tr>
             <th>Base XP</th>
-            <td>{base_experience}</td>
+            <td>{base_experience || 'Not available'}</td>
           </tr>
           <tr>
             <th>Held Items</th>

--- a/src/components/PokemonBox/StyledPokemonBox.ts
+++ b/src/components/PokemonBox/StyledPokemonBox.ts
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 // types
 import type { PokemonBoxProps } from './index';
 // styles
-import { float } from '@/components/BaseStyles';
+import { float, focusStyles } from '@/components/BaseStyles';
 // components
 import { motion } from 'framer-motion';
 
@@ -10,7 +10,6 @@ const PokeBox = styled(motion.div)<{
   $dark?: PokemonBoxProps['$dark'];
 }>`
   align-items: center;
-  /* border: 1px solid transparent; */
   border: 1px solid ${({ theme }) => theme.colors.primary.light};
   border-radius: 5px;
   display: flex;
@@ -19,14 +18,23 @@ const PokeBox = styled(motion.div)<{
   font-weight: 500;
   gap: 0.5em;
   justify-content: center;
-  max-width: 175px;
+  max-width: 125px;
   overflow: hidden;
   padding: 1em;
   position: relative;
   text-align: center;
   transition: border 0.1s ease-in-out;
   transition: box-shadow 0.05s ease-in-out;
-  width: 175px;
+  width: 125px;
+
+  ${({ theme }) => css`
+    @media ${theme.device.md} {
+      max-width: 175px;
+      width: 175px;
+    }
+  `}
+
+  ${focusStyles}
 
   &:hover {
     cursor: pointer;
@@ -71,17 +79,35 @@ const PokeBox = styled(motion.div)<{
 `;
 
 const NumberId = styled.span`
-  font-size: 2em;
+  font-size: 1.5em;
+
+  ${({ theme }) => css`
+    @media ${theme.device.md} {
+      font-size: 2em;
+    }
+  `}
 `;
 
 const PokeName = styled.span`
-  font-size: 1.5em;
+  font-size: 1em;
   text-transform: capitalize;
+
+  ${({ theme }) => css`
+    @media ${theme.device.md} {
+      font-size: 1.5em;
+    }
+  `}
 `;
 
 const PokeGen = styled.span`
-  font-size: 1em;
+  font-size: 0.85em;
   font-weight: 300;
+
+  ${({ theme }) => css`
+    @media ${theme.device.md} {
+      font-size: 1em;
+    }
+  `}
 `;
 
 export { PokeBox, NumberId, PokeName, PokeGen };

--- a/src/components/PokemonBox/StyledPokemonBox.ts
+++ b/src/components/PokemonBox/StyledPokemonBox.ts
@@ -5,6 +5,11 @@ import type { PokemonBoxProps } from './index';
 import { float, focusStyles } from '@/components/BaseStyles';
 // components
 import { motion } from 'framer-motion';
+import Link from 'next/link';
+
+const Anchor = styled(Link)`
+  ${focusStyles}
+`;
 
 const PokeBox = styled(motion.div)<{
   $dark?: PokemonBoxProps['$dark'];
@@ -33,8 +38,6 @@ const PokeBox = styled(motion.div)<{
       width: 175px;
     }
   `}
-
-  ${focusStyles}
 
   &:hover {
     cursor: pointer;
@@ -110,4 +113,4 @@ const PokeGen = styled.span`
   `}
 `;
 
-export { PokeBox, NumberId, PokeName, PokeGen };
+export { Anchor, PokeBox, NumberId, PokeName, PokeGen };

--- a/src/components/PokemonBox/index.tsx
+++ b/src/components/PokemonBox/index.tsx
@@ -5,9 +5,8 @@ import type { HTMLMotionProps } from 'framer-motion';
 // helpers
 import { removeDash, mapGeneration, fadeInUpVariant, prefixId } from '@/helpers';
 // styles
-import { PokeBox, NumberId, PokeName, PokeGen } from './StyledPokemonBox';
+import { Anchor, PokeBox, NumberId, PokeName, PokeGen } from './StyledPokemonBox';
 // components
-import Link from 'next/link';
 import ImageNext from '@/components/ImageNext';
 
 export interface PokemonBoxProps extends HTMLMotionProps<'div'> {
@@ -35,7 +34,7 @@ const PokemonBox = forwardRef(
     const generationName = useMemo(() => mapGeneration(pokemonGen), [pokemonGen]);
 
     return (
-      <Link href={`/pokemon/${defaultVarietyName || pokemonName.toLocaleLowerCase()}`}>
+      <Anchor href={`/pokemon/${defaultVarietyName || pokemonName.toLocaleLowerCase()}`}>
         <PokeBox
           ref={ref}
           $dark={$dark}
@@ -52,12 +51,13 @@ const PokemonBox = forwardRef(
               pokemonId,
             )}.png`}
             width="100"
+            height="100"
           />
           <NumberId>{`#${pokemonId}`}</NumberId>
           <PokeName>{nameFormat ? removeDash(pokemonName) : pokemonName}</PokeName>
           {generationName && <PokeGen>{generationName}</PokeGen>}
         </PokeBox>
-      </Link>
+      </Anchor>
     );
   },
 );

--- a/src/components/PokemonBox/index.tsx
+++ b/src/components/PokemonBox/index.tsx
@@ -16,17 +16,26 @@ export interface PokemonBoxProps extends HTMLMotionProps<'div'> {
   pokemonGen?: PokemonSpecies['generation']['name'];
   nameFormat?: boolean;
   $dark?: boolean;
+  defaultVarietyName?: string;
 }
 
 const PokemonBox = forwardRef(
   (
-    { pokemonId, pokemonName, pokemonGen, nameFormat = true, $dark, ...rest }: PokemonBoxProps,
+    {
+      pokemonId,
+      pokemonName,
+      pokemonGen,
+      nameFormat = true,
+      defaultVarietyName,
+      $dark,
+      ...rest
+    }: PokemonBoxProps,
     ref: Ref<HTMLDivElement>,
   ): JSX.Element => {
     const generationName = useMemo(() => mapGeneration(pokemonGen), [pokemonGen]);
 
     return (
-      <Link href={`/pokemon/${pokemonName.toLocaleLowerCase()}`}>
+      <Link href={`/pokemon/${defaultVarietyName || pokemonName.toLocaleLowerCase()}`}>
         <PokeBox
           ref={ref}
           $dark={$dark}
@@ -43,7 +52,6 @@ const PokemonBox = forwardRef(
               pokemonId,
             )}.png`}
             width="100"
-            height="100"
           />
           <NumberId>{`#${pokemonId}`}</NumberId>
           <PokeName>{nameFormat ? removeDash(pokemonName) : pokemonName}</PokeName>

--- a/src/components/Theme/theme.ts
+++ b/src/components/Theme/theme.ts
@@ -44,6 +44,7 @@ const theme = {
     },
     secondary: {
       main: 'black',
+      light: '#757575',
       contrastText: 'white',
     },
     tertiary: {

--- a/src/components/TypeBadge/StyledBadge.ts
+++ b/src/components/TypeBadge/StyledBadge.ts
@@ -4,18 +4,20 @@ import { motion } from 'framer-motion';
 import type { Type } from 'pokenode-ts';
 import type { TypeBadgeProps } from './index';
 // styles
-import { float as floatAnim } from '@/components/BaseStyles';
+import { float as floatAnim, focusStyles } from '@/components/BaseStyles';
+// components
+import Link from 'next/link';
 
 const isDarkBackground = (type: Type['name']): boolean =>
   !!type.match(/^(dark|dragon|fighting|ghost|poison|shadow|unknown)$/);
 
+const Anchor = styled(Link)`
+  ${focusStyles}
+`;
+
 const Badge = styled(motion.div)<TypeBadgeProps>`
   align-items: center;
-  background: ${({ theme, $typename, $fill }) => !$fill && theme.colors.typesHalf[$typename]};
-  border: 1px solid ${({ theme }) => theme.colors.primary.main};
   border-radius: 4px;
-  color: ${({ theme, $typename }) =>
-    isDarkBackground($typename) ? theme.colors.lightText : theme.colors.darkText};
   display: flex;
   flex-direction: row;
   font-family: 'Quicksand', sans-serif;
@@ -28,14 +30,20 @@ const Badge = styled(motion.div)<TypeBadgeProps>`
   transition: box-shadow 0.05s ease-in-out;
   width: auto;
 
-  &:hover {
-    background: ${({ theme, $typename, $fill }) => !$fill && theme.colors.types[$typename]};
-    box-shadow: ${({ theme }) => theme.colors.defaultBoxShadow};
-  }
+  ${({ theme, $typename, $fill }) => css`
+    ${!$fill && `background: ${theme.colors.typesHalf[$typename]};`};
+    border: 1px solid ${theme.colors.primary.main};
+    color: ${isDarkBackground($typename) ? theme.colors.lightText : theme.colors.darkText};
 
-  &:active {
-    box-shadow: ${({ theme }) => theme.colors.defaultInsetBoxShadow};
-  }
+    &:hover {
+      ${!$fill && `background: ${theme.colors.types[$typename]};`}
+      box-shadow: ${theme.colors.defaultBoxShadow};
+    }
+
+    &:active {
+      box-shadow: ${theme.colors.defaultInsetBoxShadow};
+    }
+  `}
 
   ${({ $iconOnly, flexmargin }) =>
     $iconOnly
@@ -78,4 +86,4 @@ const Badge = styled(motion.div)<TypeBadgeProps>`
   }
 `;
 
-export { Badge };
+export { Anchor, Badge };

--- a/src/components/TypeBadge/index.tsx
+++ b/src/components/TypeBadge/index.tsx
@@ -3,9 +3,8 @@ import type { Type } from 'pokenode-ts';
 // helpers
 import { hoverVariant } from '@/helpers';
 // styles
-import { Badge } from './StyledBadge';
+import { Anchor, Badge } from './StyledBadge';
 // components
-import Link from 'next/link';
 import TypeIcon from '@/components/TypeIcon';
 
 export interface TypeBadgeProps {
@@ -23,7 +22,7 @@ const TypeBadge = ({ $typename, hideIcon, $iconOnly, ...rest }: TypeBadgeProps):
   if (!$typename) return null;
 
   return (
-    <Link href={`/type/${$typename}`}>
+    <Anchor href={`/type/${$typename}`}>
       <Badge
         $typename={$typename}
         $iconOnly={$iconOnly}
@@ -36,7 +35,7 @@ const TypeBadge = ({ $typename, hideIcon, $iconOnly, ...rest }: TypeBadgeProps):
         {!hideIcon && <TypeIcon type={$typename} />}
         {!$iconOnly && <span>{$typename}</span>}
       </Badge>
-    </Link>
+    </Anchor>
   );
 };
 

--- a/src/helpers/gameVersion.ts
+++ b/src/helpers/gameVersion.ts
@@ -197,7 +197,6 @@ const gameVersions = [
     generation: 'Generation VII',
     genValue: 'generation-vii',
   },
-  /** 
   {
     label: 'Sword',
     value: 'sword',
@@ -212,7 +211,20 @@ const gameVersions = [
     generation: 'Generation VIII',
     genValue: 'generation-viii',
   },
-  */
+  {
+    label: 'Scarlet',
+    value: 'scarlet',
+    group: 'scarlet-violet',
+    generation: 'Generation IX',
+    genValue: 'generation-ix',
+  },
+  {
+    label: 'Violet',
+    value: 'violet',
+    group: 'scarlet-violet',
+    generation: 'Generation IX',
+    genValue: 'generation-ix',
+  },
 ];
 
 const generations = [
@@ -251,10 +263,15 @@ const generations = [
     label: 'Generation VII',
     gameVersion: 'sun',
   },
+  {
+    value: 'generation-viii',
+    label: 'Generation VIII',
+    gameVersion: 'sword',
+  },
   // {
-  //   value: 'generation-viii',
-  //   label: 'Generation VIII',
-  //   gameVersion: 'sword',
+  //   value: 'generation-ix',
+  //   label: 'Generation IX',
+  //   gameVersion: 'scarlet',
   // },
 ];
 
@@ -273,9 +290,11 @@ const mapIdToGeneration = (id: number): string => {
     return 'generation-vi';
   } else if (id > 721 && id <= 809) {
     return 'generation-vii';
-  } /** else if (id > 809 && id <= 898) {
-    return 'generation-viii'
-  } */ else {
+  } else if (id > 809 && id <= 905) {
+    return 'generation-viii';
+  } else if (id > 905 && id <= 1008) {
+    return 'generation-viii';
+  } else {
     return 'all';
   }
 };

--- a/src/helpers/moves.ts
+++ b/src/helpers/moves.ts
@@ -62,16 +62,16 @@ const filterMoves = (
 };
 
 const getMachineNames = async (machineMoves: FilteredMove[]): Promise<string[]> => {
-  const machineClient = new MachineClient({
-    cacheOptions: { maxAge: 0, limit: false },
-  });
+  const machineClient = new MachineClient();
   // requests array
   const machineRequests = [];
   // create a request for each move
   machineMoves.forEach(move => {
-    machineRequests.push(
-      machineClient.getMachineById(getIdFromMachine(move.current_version_machine)),
-    );
+    if (move?.current_version_machine) {
+      machineRequests.push(
+        machineClient.getMachineById(getIdFromMachine(move.current_version_machine)),
+      );
+    }
   });
 
   const machines: Machine[] = await Promise.all(machineRequests);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   try {
     const [pokemonData, typesData] = await Promise.all([
-      api.listPokemons(0, 809),
+      api.listPokemons(0, 905),
       api.listTypes(0, 18),
     ]);
 

--- a/src/pages/pokemon/[pokemonId].tsx
+++ b/src/pages/pokemon/[pokemonId].tsx
@@ -142,7 +142,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       { results: allTypesDataResults },
       pokemonDataResults,
     ] = await Promise.all([
-      pokemonClient.listPokemons(0, 809),
+      pokemonClient.listPokemons(0, 905),
       pokemonClient.listTypes(),
       pokemonClient.getPokemonByName(pokemonName),
     ]);
@@ -152,7 +152,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       return { notFound: true };
     }
 
-    if (pokemonDataResults.id > 809) return { notFound: true };
+    if (pokemonDataResults.id > 905) return { notFound: true };
 
     // abilities requests array
     let pokemonAbilities = [];
@@ -213,7 +213,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         const secondEvoData = await pokemonClient.getPokemonSpeciesByName(
           second_evolution.species.name,
         );
-        if (secondEvoData.id <= 809) {
+        if (secondEvoData.id <= 905) {
           evolutionChainPokemon.secondEvolution.push({
             species: secondEvoData,
             evolutionDetails: second_evolution.evolution_details,
@@ -232,7 +232,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
           const thirdEvoData = await pokemonClient.getPokemonSpeciesByName(
             third_evolution.species.name,
           );
-          if (thirdEvoData.id <= 809) {
+          if (thirdEvoData.id <= 905) {
             evolutionChainPokemon.secondEvolution[i].thirdEvolution.push({
               species: thirdEvoData,
               evolutionDetails: third_evolution.evolution_details,

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const routes = [''];
 
   try {
-    const [pokemonData, typesData] = await Promise.all([api.listPokemons(0, 809), api.listTypes()]);
+    const [pokemonData, typesData] = await Promise.all([api.listPokemons(0, 905), api.listTypes()]);
 
     if (!pokemonData || !typesData) {
       return { notFound: true };

--- a/src/pages/type/[typeId].tsx
+++ b/src/pages/type/[typeId].tsx
@@ -80,7 +80,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     // fetch data
     const [{ results: allPokemonDataResults }, { results: allTypesDataResults }, typeData] =
       await Promise.all([
-        pokemonClient.listPokemons(0, 809),
+        pokemonClient.listPokemons(0, 905),
         pokemonClient.listTypes(),
         pokemonClient.getTypeByName(typeName),
       ]);
@@ -103,7 +103,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       .map(({ pokemon }) => {
         const id = getIdFromPokemon(pokemon.url);
         // if pokemon not gen 8
-        if (id <= 809) {
+        if (id <= 905) {
           return {
             ...pokemon,
             id: id,


### PR DESCRIPTION
This PR adds support for Generation 8 Pokemon from `Pokeapi`. 
Some data is still incomplete for some Pokemon, most data is accurate.

Corrects the default variety name in the Sprites section.
Improves focus states in `Homepage` components.