### PR TITLE
[Pokemon] Updates game version logic

### DIFF
--- a/src/services/PokedexApi.ts
+++ b/src/services/PokedexApi.ts
@@ -1,0 +1,17 @@
+import type { PokemonSpecies } from 'pokenode-ts';
+import MainClient from './MainClient';
+import { getResourceId } from '@/helpers';
+
+export const PokedexApi = {
+  getNamesBySpecies: async (species: PokemonSpecies) => {
+    // Fetch every pokedex in parallel
+    const responses = await Promise.all(
+      species.pokedex_numbers.map(({ pokedex }) =>
+        MainClient.game.getPokedexById(getResourceId(pokedex.url)),
+      ),
+    );
+
+    // Process the responses and return version group names
+    return responses.flatMap(({ version_groups }) => version_groups.map(({ name }) => name));
+  },
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,6 +10,7 @@ export * from './LocationApi';
 export { MachineApi, type MoveMachinesData } from './MachineApi';
 export { MovesApi } from './MovesApi';
 export { NatureApi } from './NatureApi';
+export { PokedexApi } from './PokedexApi';
 export { PokemonApi } from './PokemonApi';
 export { SpeciesApi } from './SpeciesApi';
 export { TypesApi } from './TypesApi';


### PR DESCRIPTION
### Summary
This pull request refactors the `GameVersionContext` to improve performance and readability, introduces a new `PokedexApi` service to handle Pokédex data, and updates service exports to include the new API.

### Detailed Changes
- **Refactoring of `GameVersionContext` (`src/context/GameVersionContext.tsx`):**
  - Removed redundant state management for `dropdownOptions`.
  - Utilized `useMemo` to directly compute dropdown options based on `pokemon` data.
  - Simplified the logic for setting the initial game version, ensuring a valid selection.
  - Consolidated multiple `useEffect` hooks into a single efficient `useMemo` block, reducing unnecessary re-renders.
  
- **Addition of `PokedexApi` (`src/services/PokedexApi.ts`):**
  - Created a new `PokedexApi` service to manage fetching and processing Pokédex data.
  - Implemented `getNamesBySpecies` function to fetch Pokédex entries in parallel and extract version group names.

- **Service Exports Update (`src/services/index.ts`):**
  - Added `PokedexApi` to the list of service exports for consistent usage across the application.
